### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- NPM status image to README.md
 
 ## [0.1.0] - 2019-12-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.1] - 2019-12-31
 ### Added
 - NPM status image to README.md
 - Error message when `task` callback returns falsy values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 
 ### Fixed
 - Fix task duration calculation
+- Prevent subdirectories of existing watch directories from being watched
+- Remove existing watch directories that are subdirectories of new watch directories
 
 ## [0.1.0] - 2019-12-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 ## [Unreleased]
 ### Added
 - NPM status image to README.md
+- Error message when `task` callback returns falsy values
+
+### Changed
+- Slight improvements to README.md whitespace
+- Slight improvements to README.md 'Basic Usage' example
+
+### Fixed
+- Fix task duration calculation
 
 ## [0.1.0] - 2019-12-31
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Webpack Streaming Task Plugin
 Execute tasks during Webpack compilation
 
+[![NPM](https://nodei.co/npm/webpack-streaming-task-plugin.png)](https://nodei.co/npm/webpack-streaming-task-plugin/)
+
 ## Overview
 This plugin executes streaming tasks during Webpack compilation, and can be
 used to easily leverage Gulp plugins while using Webpack.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const WebpackConfig = {
         return task
           .pipe(cssnano())
           .pipe(rename({
-            suffix: 'min',
+            suffix: '.min',
           }));
       },
     }),

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ used to easily leverage Gulp plugins while using Webpack.
 
 ## Installation
 Install the plugin with npm:
+
 `$ npm install webpack-streaming-task-plugin --save-dev`
 
 Or with Yarn:
+
 `$ yarn add webpack-streaming-task-plugin --dev`
 
 ## Basic Usage

--- a/index.js
+++ b/index.js
@@ -73,9 +73,9 @@ const getDurationString = function(duration) {
   let seconds = 0;
 
   // Calculate durations.
-  for (hours = 0; remaining > HOUR; remaining -= HOUR) { hours ++ }
-  for (minutes = 0; remaining > MINUTE; remaining -= MINUTE) { minutes ++ }
-  for (seconds = 0; remaining > SECOND; remaining -= SECOND) { seconds ++ }
+  for (hours = 0; remaining >= HOUR; remaining -= HOUR) { hours ++ }
+  for (minutes = 0; remaining >= MINUTE; remaining -= MINUTE) { minutes ++ }
+  for (seconds = 0; remaining >= SECOND; remaining -= SECOND) { seconds ++ }
   let ms = remaining;
 
   // Generate output string.

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ const getDurationString = function(duration) {
   // Calculate durations.
   for (hours = 0; remaining > HOUR; remaining -= HOUR) { hours ++ }
   for (minutes = 0; remaining > MINUTE; remaining -= MINUTE) { minutes ++ }
-  for (seconds = 0; seconds > SECOND; remaining -= SECOND) { seconds ++ }
+  for (seconds = 0; remaining > SECOND; remaining -= SECOND) { seconds ++ }
   let ms = remaining;
 
   // Generate output string.

--- a/index.js
+++ b/index.js
@@ -54,6 +54,19 @@ const emitError = function(compilation, message, err = null) {
 }
 
 /**
+ * Determines if child is a subdirectory of parent.
+ *
+ * @param  {string}  child - Path to potential subdirectory.
+ * @param  {string}  parent - Path to potential parent directory.
+ *
+ * @return {Boolean} True if child is a subdirectory of parent, false otherwise.
+ */
+const isDirectorySubdirectory = function(child, parent) {
+  const relative = path.relative(parent, child);
+  return relative && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+/**
  * Returns a string describing the given duration in human-readable format.
  *
  * @param  {integer} duration Millisecond duration.

--- a/index.js
+++ b/index.js
@@ -326,15 +326,21 @@ class WebpackStreamingTaskPlugin {
 
           // TODO Replace console.log with better output method.
           console.log(`Executing task: ${colors.yellow(getTaskName())}`);
-          const taskResult = task(stream)
-            .on('error', onTaskError)
-            .on('finish', () => {
+          const taskResult = task(stream);
+          if (taskResult) {
+            taskResult.on('error', onTaskError);
+            taskResult.on('finish', () => {
               taskResult
-                .pipe(vfs.dest(destination))
                 .on('error', onTaskError)
                 .on('finish', onTaskFinish)
+                .pipe(vfs.dest(destination))
             });
-        } else {
+          }
+          else {
+            callback();
+          }
+        }
+        else {
           callback();
         }
 

--- a/index.js
+++ b/index.js
@@ -326,7 +326,13 @@ class WebpackStreamingTaskPlugin {
 
           // TODO Replace console.log with better output method.
           console.log(`Executing task: ${colors.yellow(getTaskName())}`);
-          const taskResult = task(stream)
+          const taskResult = task(stream);
+          if (!taskResult) {
+            emitError(compilation, `No stream retrieved from '${getTaskName()}' task. Is the return statement missing?`);
+            callback();
+            return;
+          }
+          taskResult
             .on('error', onTaskError)
             .on('finish', () => {
               taskResult

--- a/index.js
+++ b/index.js
@@ -326,19 +326,14 @@ class WebpackStreamingTaskPlugin {
 
           // TODO Replace console.log with better output method.
           console.log(`Executing task: ${colors.yellow(getTaskName())}`);
-          const taskResult = task(stream);
-          if (taskResult) {
-            taskResult.on('error', onTaskError);
-            taskResult.on('finish', () => {
+          const taskResult = task(stream)
+            .on('error', onTaskError)
+            .on('finish', () => {
               taskResult
+                .pipe(vfs.dest(destination))
                 .on('error', onTaskError)
                 .on('finish', onTaskFinish)
-                .pipe(vfs.dest(destination))
             });
-          }
-          else {
-            callback();
-          }
         }
         else {
           callback();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-streaming-task-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Execute streaming tasks during Webpack compilation",
   "main": "index.js",
   "repository": "https://github.com/joe-damore/webpack-streaming-task-plugin.git",


### PR DESCRIPTION
## [0.1.1] - 2019-12-31
### Added
- NPM status image to README.md
- Error message when `task` callback returns falsy values

### Changed
- Slight improvements to README.md whitespace
- Slight improvements to README.md 'Basic Usage' example

### Fixed
- Fix task duration calculation
- Prevent subdirectories of existing watch directories from being watched
- Remove existing watch directories that are subdirectories of new watch directories