### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ and this project adheres to
 ## [Unreleased]
 ### Added
 - `watchMode.includeSourceDirectories` option to replace `watchSourceDirectories`
+- `watchMode.alwaysRun` option to replace `always`
 - `watchMode.skipInitialRun` option to skip task during inital run while in watch mode
 - `watchMode.changedFilesOnly` option only include changed files in task stream while in watch mode
 - Additional keywords to `package.json`
 
 ### Changed
 - Deprecate `watchSourceDirectories` option in favor of `watchMode.includeSourceDirectories`
+- Deprecate `always` option in favor of `watchMode.alwaysRun`
 
 ## [0.1.1] - 2019-12-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 - `watchMode.includeSourceDirectories` option to replace `watchSourceDirectories`
 - `watchMode.skipInitialRun` option to skip task during inital run while in watch mode
 - `watchMode.changedFilesOnly` option only include changed files in task stream while in watch mode
+- Additional keywords to `package.json`
 
 ### Changed
 - Deprecate `watchSourceDirectories` option in favor of `watchMode.includeSourceDirectories`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2020-01-03
 ### Added
 - `watchMode.includeSourceDirectories` option to replace `watchSourceDirectories`
 - `watchMode.alwaysRun` option to replace `always`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `watchMode.includeSourceDirectories` option to replace `watchSourceDirectories`
+- `watchMode.skipInitialRun` option to skip task during inital run while in watch mode
+- `watchMode.changedFilesOnly` option only include changed files in task stream while in watch mode
+
+### Changed
+- Deprecate `watchSourceDirectories` option in favor of `watchMode.includeSourceDirectories`
 
 ## [0.1.1] - 2019-12-31
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,5 +53,12 @@ The `options` object can contain the following properties:
 - `destination`: (String) Destination path for task output. (Optional, default `'./'`)
 - `task`: (Function) Task function. Includes a `task` parameter with which to pipe output.
 - `always`: (Boolean) For watch mode only. When `true`, this task will always be executed when Webpack runs, even if files specified in `source` are unchanged. (Optional, default `false`)
-- `watchSourceDirectories`: (Boolean) For watch mode only. When `true`, any changes to any directories containing files specified in `source` trigger a Webpack compilation. This can be useful when creating a new file or directory should trigger a task to execute. (Optional, default `false`)
 - `name`: (String) Name of task, used in log output (Optional)
+- `watchMode`: (Object) Configuration object for options related to Webpack's watch mode. (Optional)
+- `watchMode.includeSourceDirectories`: (Boolean) Only applies when in watch mode. By default, Webpack only watches for changes to the files specified by `source`, but directory-level changes (new files, new child directories, etc.) are ignored. When `includeSourceDirectories` is `true`, changes to any directories that contain files specified in `source` will trigger recompilation. (Optional, default `false`)
+- `watchMode.skipInitialRun`: (Boolean) Only applies when in watch mode. When `true`, this task is not executed upon Webpack's initial run. Instead, it will only run once changes to its source files are detected. (Optional, default `false`)
+
+### Deprecated Options
+The following options should no longer be used and will be removed in future releases. They only exist for legacy compatibility.
+
+- `watchSourceDirectories`: (Boolean) Deprecated. For watch mode only. Serves the same purpose as `watchMode.includeSourceDirectories`. **This option is deprecated. Use watchMode.includeSourceDirectories instead.**

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The `options` object can contain the following properties:
 - `watchMode`: (Object) Configuration object for options related to Webpack's watch mode. (Optional)
 - `watchMode.includeSourceDirectories`: (Boolean) Only applies when in watch mode. By default, Webpack only watches for changes to the files specified by `source`, but directory-level changes (new files, new child directories, etc.) are ignored. When `includeSourceDirectories` is `true`, changes to any directories that contain files specified in `source` will trigger recompilation. (Optional, default `false`)
 - `watchMode.skipInitialRun`: (Boolean) Only applies when in watch mode. When `true`, this task is not executed upon Webpack's initial run. Instead, it will only run once changes to its source files are detected. (Optional, default `false`)
+- `watchMode.changedFilesOnly`: (Boolean) Only applies when in watch mode. When `true`, only files which have changed since last run will be included in the stream passed to this task. (Optional, default `false`)
 
 ### Deprecated Options
 The following options should no longer be used and will be removed in future releases. They only exist for legacy compatibility.

--- a/README.md
+++ b/README.md
@@ -52,14 +52,15 @@ The `options` object can contain the following properties:
 - `source`: (String or Array) Glob string or array of glob strings describing task input.
 - `destination`: (String) Destination path for task output. (Optional, default `'./'`)
 - `task`: (Function) Task function. Includes a `task` parameter with which to pipe output.
-- `always`: (Boolean) For watch mode only. When `true`, this task will always be executed when Webpack runs, even if files specified in `source` are unchanged. (Optional, default `false`)
 - `name`: (String) Name of task, used in log output (Optional)
 - `watchMode`: (Object) Configuration object for options related to Webpack's watch mode. (Optional)
-- `watchMode.includeSourceDirectories`: (Boolean) Only applies when in watch mode. By default, Webpack only watches for changes to the files specified by `source`, but directory-level changes (new files, new child directories, etc.) are ignored. When `includeSourceDirectories` is `true`, changes to any directories that contain files specified in `source` will trigger recompilation. (Optional, default `false`)
-- `watchMode.skipInitialRun`: (Boolean) Only applies when in watch mode. When `true`, this task is not executed upon Webpack's initial run. Instead, it will only run once changes to its source files are detected. (Optional, default `false`)
-- `watchMode.changedFilesOnly`: (Boolean) Only applies when in watch mode. When `true`, only files which have changed since last run will be included in the stream passed to this task. (Optional, default `false`)
+- `watchMode.includeSourceDirectories`: (Boolean) Only applies in watch mode. By default, Webpack only watches for changes to the files specified by `source`, but directory-level changes (new files, new child directories, etc.) are ignored. When `includeSourceDirectories` is `true`, changes to any directories that contain files specified in `source` will trigger recompilation. (Optional, default `false`)
+- `watchMode.skipInitialRun`: (Boolean) Only applies in watch mode. When `true`, this task is not executed upon Webpack's initial run. Instead, it will only run once changes to its source files are detected. (Optional, default `false`)
+- `watchMode.alwaysRun`: (Boolean) Only applies in watch mode. When `true`, this task is always executed when Webpack runs, even if files specified in `source` are unchanged. If `watchMode.skipInitialRun` is also `true`, `skipInitialRun` takes priority and the first run will be skipped despite `alwaysRun` being `true`. (Optional, default `false`)
+- `watchMode.changedFilesOnly`: (Boolean) Only applies in watch mode. When `true`, only files which have changed since last run will be included in the stream passed to this task. (Optional, default `false`)
 
 ### Deprecated Options
 The following options should no longer be used and will be removed in future releases. They only exist for legacy compatibility.
 
-- `watchSourceDirectories`: (Boolean) Deprecated. For watch mode only. Serves the same purpose as `watchMode.includeSourceDirectories`. **This option is deprecated. Use watchMode.includeSourceDirectories instead.**
+- `always`: (Boolean) Deprecated. For watch mode only. Serves the same purpose as `watchMode.alwaysRun`. **This option is deprecated. Use `watchMode.alwaysRun` instead.**
+- `watchSourceDirectories`: (Boolean) Deprecated. For watch mode only. Serves the same purpose as `watchMode.includeSourceDirectories`. **This option is deprecated. Use `watchMode.includeSourceDirectories` instead.**

--- a/index.js
+++ b/index.js
@@ -412,7 +412,7 @@ class WebpackStreamingTaskPlugin {
         // Determine which files have changed.
         const changedFiles = getChangedFiles();
         const changedDependencies = getChangedDependencies(dependencyFiles, changedFiles);
-        const taskFileHasChanged = (changedDependencies > 0);
+        const taskFileHasChanged = (changedDependencies.length > 0);
 
         if (shouldSkip) {
           // TODO Replace console.log with better output method.

--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ class WebpackStreamingTaskPlugin {
         skipInitialRun = false,
         changedFilesOnly = false,
         alwaysRun = false,
-      }
+      },
       watchSourceDirectories = undefined,
       always = undefined,
     } = this.options;

--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
   },
   "keywords": [
     "webpack",
+    "webpack-plugin",
     "plugin",
+    "stream",
     "streaming",
+    "vinyl",
     "tasks",
     "gulp"
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-streaming-task-plugin",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Execute streaming tasks during Webpack compilation",
   "main": "index.js",
   "repository": "https://github.com/joe-damore/webpack-streaming-task-plugin.git",


### PR DESCRIPTION
## [0.2.0] - 2020-01-03
### Added
- `watchMode.includeSourceDirectories` option to replace `watchSourceDirectories`
- `watchMode.alwaysRun` option to replace `always`
- `watchMode.skipInitialRun` option to skip task during inital run while in watch mode
- `watchMode.changedFilesOnly` option only include changed files in task stream while in watch mode
- Additional keywords to `package.json`

### Changed
- Deprecate `watchSourceDirectories` option in favor of `watchMode.includeSourceDirectories`
- Deprecate `always` option in favor of `watchMode.alwaysRun`