### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.1] - 2020-01-04
 ### Changed
 - Slight improvements to README.md 'Basic Usage' example
 - Clarify distinction between task execution error and task output error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Clarify error message when task output includes an error
+- Use `bach` to execute tasks
+
 ### Fixed
 - Fix error that occurs when `watchMode` option is not specified
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to
 
 ### Fixed
 - Prevent error when `watchMode` option is not specified
-- Prevent piping to `vfs.dest` when `destination` is `null` or `undefined`
+- Prevent piping to `vfs.dest` when `destination` is `null`
 
 ## [0.2.0] - 2020-01-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Slight improvements to README.md 'Basic Usage' example
 
 ## [0.2.0] - 2020-01-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to
 ## [Unreleased]
 ### Changed
 - Slight improvements to README.md 'Basic Usage' example
-- Clarify error message when task output includes an error
+- Clarify distinction between task execution error and task output error
 - Use `bach` to execute tasks
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 
 ### Fixed
 - Fix error that occurs when `watchMode` option is not specified
+- Avoid piping to `vfs.dest` when `destination` is `null` or `undefined`
 
 ## [0.2.0] - 2020-01-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to
 - Use `bach` to execute tasks
 
 ### Fixed
-- Fix error that occurs when `watchMode` option is not specified
-- Avoid piping to `vfs.dest` when `destination` is `null` or `undefined`
+- Prevent error when `watchMode` option is not specified
+- Prevent piping to `vfs.dest` when `destination` is `null` or `undefined`
 
 ## [0.2.0] - 2020-01-03
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix error that occurs when `watchMode` option is not specified
 
 ## [0.2.0] - 2020-01-03
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ rename a CSS file that is separate from the main Webpack bundle.
 
 ```js
 const WebpackStreamingTaskPlugin = require('webpack-streaming-task-plugin');
+const cssnano = require('gulp-cssnano');
+const rename = require('gulp-rename');
 
 const WebpackConfig = {
   entry: './src/js/index.js',

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ const WebpackConfig = {
 The `options` object can contain the following properties:
 
 - `source`: (String or Array) Glob string or array of glob strings describing task input.
-- `destination`: (String) Destination path for task output. (Optional, default `'./'`)
+- `destination`: (String) Destination path for task output. Set to `null` to prevent piping output to the filesystem. (Optional, default `'./'`)
 - `task`: (Function) Task function. Includes a `task` parameter with which to pipe output.
 - `name`: (String) Name of task, used in log output (Optional)
 - `watchMode`: (Object) Configuration object for options related to Webpack's watch mode. (Optional)

--- a/index.js
+++ b/index.js
@@ -449,7 +449,10 @@ class WebpackStreamingTaskPlugin {
         if (shouldSkip) {
           // TODO Replace console.log with better output method.
           console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run`);
+          // Update file timestamp memory.
+          this.prevTimestamps = compilation.fileTimestamps;
           callback();
+          return;
         }
         if ((noPreviousTimestamps || taskFileHasChanged || shouldAlwaysRun) && !shouldSkip) {
           let streamSource = source;

--- a/index.js
+++ b/index.js
@@ -454,7 +454,7 @@ class WebpackStreamingTaskPlugin {
           callback();
           return;
         }
-        if ((noPreviousTimestamps || taskFileHasChanged || shouldAlwaysRun) && !shouldSkip) {
+        if (noPreviousTimestamps || taskFileHasChanged || shouldAlwaysRun) {
           let streamSource = source;
 
           if (taskFileHasChanged && changedFilesOnly) {

--- a/index.js
+++ b/index.js
@@ -182,7 +182,7 @@ class WebpackStreamingTaskPlugin {
          *
          * @param  {Map|null} fileTimestamps Compilation file timestamps.
          */
-        const beforeCallback(fileTimestamps) {
+        const beforeCallback = function(fileTimestamps) {
           if (fileTimestamps) {
             this.prevTimestamps = fileTimestamps;
           }

--- a/index.js
+++ b/index.js
@@ -482,14 +482,13 @@ class WebpackStreamingTaskPlugin {
             if (error) {
               onTaskResultError(error);
             }
+            // Update file timestamp memory.
+            plugin.prevTimestamps = compilation.fileTimestamps;
           });
 
           return;
         }
         callback();
-
-        // Update file timestamp memory.
-        this.prevTimestamps = compilation.fileTimestamps;
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -493,6 +493,9 @@ class WebpackStreamingTaskPlugin {
             callback();
           });
         }
+        else {
+          callback();
+        }
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ class WebpackStreamingTaskPlugin {
          */
         const beforeCallback = function(fileTimestamps) {
           if (fileTimestamps) {
-            this.prevTimestamps = fileTimestamps;
+            plugin.prevTimestamps = fileTimestamps;
           }
           callback();
         }

--- a/index.js
+++ b/index.js
@@ -455,7 +455,10 @@ class WebpackStreamingTaskPlugin {
           const stream = vfs.src(streamSource);
 
           const invoke = bach.settleSeries(
-            () => { return task(stream); },
+            () => {
+              return task(stream)
+                .pipe(vfs.dest(destination));
+            },
             {
               create: function() {
               },

--- a/index.js
+++ b/index.js
@@ -402,7 +402,6 @@ class WebpackStreamingTaskPlugin {
         const onTaskFinish = function() {
           const taskDuration = (new Date() - taskStartTime);
           console.log(`Finished executing ${colors.yellow(getTaskName())} task in ${colors.whiteBright(getDurationString(taskDuration))}\n`);
-          callback();
         }
 
         // Validate options.
@@ -493,6 +492,7 @@ class WebpackStreamingTaskPlugin {
             }
             // Update file timestamp memory.
             plugin.prevTimestamps = compilation.fileTimestamps;
+            callback();
           });
         }
     });

--- a/index.js
+++ b/index.js
@@ -451,7 +451,6 @@ class WebpackStreamingTaskPlugin {
           // TODO Replace console.log with better output method.
           console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run`);
           // Update file timestamp memory.
-          this.prevTimestamps = compilation.fileTimestamps;
           callback();
           return;
         }
@@ -486,12 +485,11 @@ class WebpackStreamingTaskPlugin {
               },
             });
 
+          this.prevTimestamps = compilation.fileTimestamps;
           invoke((error, results) => {
             if (error) {
               onTaskResultError(error);
             }
-            // Update file timestamp memory.
-            plugin.prevTimestamps = compilation.fileTimestamps;
             callback();
           });
         }

--- a/index.js
+++ b/index.js
@@ -449,6 +449,7 @@ class WebpackStreamingTaskPlugin {
         if (shouldSkip) {
           // TODO Replace console.log with better output method.
           console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run`);
+          callback();
         }
         if ((noPreviousTimestamps || taskFileHasChanged || shouldAlwaysRun) && !shouldSkip) {
           let streamSource = source;

--- a/index.js
+++ b/index.js
@@ -489,7 +489,6 @@ class WebpackStreamingTaskPlugin {
             plugin.prevTimestamps = compilation.fileTimestamps;
           });
         }
-        callback();
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -132,15 +132,16 @@ class WebpackStreamingTaskPlugin {
       destination = './',
       task,
       name,
-      watchMode: {
-        includeSourceDirectories = false,
-        skipInitialRun = false,
-        changedFilesOnly = false,
-        alwaysRun = false,
-      },
       watchSourceDirectories = undefined,
       always = undefined,
     } = this.options;
+
+    const {
+      includeSourceDirectories = false,
+      skipInitialRun = false,
+      changedFilesOnly = false,
+      alwaysRun = false,
+    } = (this.options.watchMode || {});
 
     /**
      * Returns the most suitable name for this task.

--- a/index.js
+++ b/index.js
@@ -330,7 +330,12 @@ class WebpackStreamingTaskPlugin {
         const getChangedFiles = function() {
           const timestamps = Array.from(compilation.fileTimestamps.keys());
           return timestamps.filter((filepath) => {
-            const prevTime = (plugin.prevTimestamps.get(filepath) || plugin.startTime);
+            const prevTime = (() => {
+              if (!plugin.prevTimestamps) {
+                return plugin.startTime;
+              }
+              return (plugin.prevTimestamps.get(filepath) || plugin.startTime);
+            })();
             const newTime = (compilation.fileTimestamps.get(filepath) || Infinity);
 
             return (prevTime < newTime);

--- a/index.js
+++ b/index.js
@@ -118,6 +118,7 @@ class WebpackStreamingTaskPlugin {
     this.startTime = Date.now();
     this.prevTimestamps = null;
     this.hasRun = false;
+    this.hasSkipped = false;
 
     this.apply = this.apply.bind(this);
   }
@@ -430,7 +431,7 @@ class WebpackStreamingTaskPlugin {
           this.prevTimestamps.size < 1);
 
         // Check if task should be skipped.
-        const shouldSkip = (compiler.watchMode && noPreviousTimestamps && skipInitialRun);
+        const shouldSkip = (compiler.watchMode && !this.hasRun && !this.hasSkipped && skipInitialRun);
 
         // Get array of files and directories that this task depends on.
         const dependencyFiles = await getDependencyFiles();
@@ -505,6 +506,7 @@ class WebpackStreamingTaskPlugin {
         }
 
         if (shouldSkip) {
+          this.hasSkipped = true;
           console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run\n`);
         }
 

--- a/index.js
+++ b/index.js
@@ -325,16 +325,18 @@ class WebpackStreamingTaskPlugin {
         /**
          * Gets an array of files that have been changed since the last run.
          *
+         * @param {Map|null} prevTimestamps File timestamps from previous run.
+         *
          * @return {array} Array of files that have been changed.
          */
-        const getChangedFiles = function() {
+        const getChangedFiles = function(prevTimestamps) {
           const timestamps = Array.from(compilation.fileTimestamps.keys());
           return timestamps.filter((filepath) => {
             const prevTime = (() => {
-              if (!plugin.prevTimestamps) {
+              if (!prevTimestamps) {
                 return plugin.startTime;
               }
-              return (plugin.prevTimestamps.get(filepath) || plugin.startTime);
+              return (prevTimestamps.get(filepath) || plugin.startTime);
             })();
             const newTime = (compilation.fileTimestamps.get(filepath) || Infinity);
 
@@ -442,7 +444,7 @@ class WebpackStreamingTaskPlugin {
         }
 
         // Determine which files have changed.
-        const changedFiles = getChangedFiles();
+        const changedFiles = getChangedFiles(this.prevTimestamps);
         const changedDependencies = getChangedDependencies(dependencyFiles, changedFiles);
         const taskFileHasChanged = (changedDependencies.length > 0);
 

--- a/index.js
+++ b/index.js
@@ -508,7 +508,7 @@ class WebpackStreamingTaskPlugin {
           console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run\n`);
         }
 
-        wrapCallback(compilation.fileTimestamps);
+        beforeCallback(compilation.fileTimestamps);
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -485,8 +485,6 @@ class WebpackStreamingTaskPlugin {
             // Update file timestamp memory.
             plugin.prevTimestamps = compilation.fileTimestamps;
           });
-
-          return;
         }
         callback();
     });

--- a/index.js
+++ b/index.js
@@ -447,15 +447,7 @@ class WebpackStreamingTaskPlugin {
         const changedDependencies = getChangedDependencies(dependencyFiles, changedFiles);
         const taskFileHasChanged = (changedDependencies.length > 0);
 
-        if (shouldSkip) {
-          // TODO Replace console.log with better output method.
-          console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run`);
-          // Update file timestamp memory.
-          this.prevTimestamps = compilation.fileTimestamps;
-          callback();
-          return;
-        }
-        if (noPreviousTimestamps || taskFileHasChanged || shouldAlwaysRun) {
+        if ((noPreviousTimestamps || taskFileHasChanged || shouldAlwaysRun) && !shouldSkip) {
           let streamSource = source;
 
           if (taskFileHasChanged && changedFilesOnly) {
@@ -495,6 +487,10 @@ class WebpackStreamingTaskPlugin {
           });
         }
         else {
+          if (shouldSkip) {
+            console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run\n`);
+          }
+          this.prevTimestamps = compilation.fileTimestamps;
           callback();
         }
     });

--- a/index.js
+++ b/index.js
@@ -485,14 +485,15 @@ class WebpackStreamingTaskPlugin {
             }
             callback();
           });
+          return;
         }
-        else {
-          if (shouldSkip) {
-            console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run\n`);
-          }
-          this.prevTimestamps = compilation.fileTimestamps;
-          callback();
+
+        if (shouldSkip) {
+          console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run\n`);
         }
+
+        this.prevTimestamps = compilation.fileTimestamps;
+        callback();
     });
   }
 }

--- a/index.js
+++ b/index.js
@@ -461,6 +461,9 @@ class WebpackStreamingTaskPlugin {
 
           const invoke = bach.settleSeries(
             () => {
+              if (!destination) {
+                return task(stream);
+              }
               return task(stream)
                 .pipe(vfs.dest(destination));
             },

--- a/index.js
+++ b/index.js
@@ -414,7 +414,7 @@ class WebpackStreamingTaskPlugin {
         // Determine if any previous timestamps have been saved.
         const noPreviousTimestamps = (
           this.prevTimestamps === null ||
-          this.prevTimestamps.length < 1);
+          this.prevTimestamps.size < 1);
 
         // Check if task should be skipped.
         const shouldSkip = (compiler.watchMode && noPreviousTimestamps && skipInitialRun);
@@ -451,6 +451,7 @@ class WebpackStreamingTaskPlugin {
           // TODO Replace console.log with better output method.
           console.log(`Skipping task '${colors.yellow(getTaskName())}' during initial run`);
           // Update file timestamp memory.
+          this.prevTimestamps = compilation.fileTimestamps;
           callback();
           return;
         }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "private": false,
   "dependencies": {
     "ansi-colors": "^4.1.1",
+    "bach": "^1.2.0",
     "globby": "^10.0.1",
     "vinyl-fs": "^3.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-streaming-task-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Execute streaming tasks during Webpack compilation",
   "main": "index.js",
   "repository": "https://github.com/joe-damore/webpack-streaming-task-plugin.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,10 +59,86 @@ append-buffer@^1.0.2:
   dependencies:
     buffer-equal "^1.0.0"
 
+arr-filter@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/arr-filter/-/arr-filter-1.1.2.tgz#43fdddd091e8ef11aa4c45d9cdc18e2dff1711ee"
+  integrity sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=
+  dependencies:
+    make-iterator "^1.0.0"
+
+arr-flatten@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  integrity sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+
+arr-map@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/arr-map/-/arr-map-2.0.2.tgz#3a77345ffc1cf35e2a91825601f9e58f2e24cac4"
+  integrity sha1-Onc0X/wc814qkYJWAfnljy4kysQ=
+  dependencies:
+    make-iterator "^1.0.0"
+
+array-each@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/array-each/-/array-each-1.0.1.tgz#a794af0c05ab1752846ee753a1f211a05ba0c44f"
+  integrity sha1-p5SvDAWrF1KEbudTofIRoFugxE8=
+
+array-initial@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/array-initial/-/array-initial-1.1.0.tgz#2fa74b26739371c3947bd7a7adc73be334b3d795"
+  integrity sha1-L6dLJnOTccOUe9enrcc74zSz15U=
+  dependencies:
+    array-slice "^1.0.0"
+    is-number "^4.0.0"
+
+array-last@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/array-last/-/array-last-1.3.0.tgz#7aa77073fec565ddab2493f5f88185f404a9d336"
+  integrity sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==
+  dependencies:
+    is-number "^4.0.0"
+
+array-slice@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/array-slice/-/array-slice-1.1.0.tgz#e368ea15f89bc7069f7ffb89aec3a6c7d4ac22d4"
+  integrity sha512-B1qMD3RBP7O8o0H2KbrXDyB0IccejMF15+87Lvlor12ONPRHP6gTjXMNkt/d3ZuOGbAe66hFmaCfECI24Ufp6w==
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+async-done@^1.2.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/async-done/-/async-done-1.3.2.tgz#5e15aa729962a4b07414f528a88cdf18e0b290a2"
+  integrity sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.2"
+    process-nextick-args "^2.0.0"
+    stream-exhaust "^1.0.1"
+
+async-settle@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-settle/-/async-settle-1.0.0.tgz#1d0a914bb02575bec8a8f3a74e5080f72b2c0c6b"
+  integrity sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=
+  dependencies:
+    async-done "^1.2.2"
+
+bach@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/bach/-/bach-1.2.0.tgz#4b3ce96bf27134f79a1b414a51c14e34c3bd9880"
+  integrity sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=
+  dependencies:
+    arr-filter "^1.1.1"
+    arr-flatten "^1.0.1"
+    arr-map "^2.0.0"
+    array-each "^1.0.0"
+    array-initial "^1.0.0"
+    array-last "^1.1.1"
+    async-done "^1.2.2"
+    async-settle "^1.0.0"
+    now-and-later "^2.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -339,6 +415,11 @@ is-negated-glob@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
   integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
 
+is-number@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-4.0.0.tgz#0026e37f5454d73e356dfe6564699867c6a7f0ff"
+  integrity sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -383,6 +464,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
+  integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
 lazystream@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lazystream/-/lazystream-1.0.0.tgz#f6995fe0f820392f61396be89462407bb77168e4"
@@ -396,6 +482,13 @@ lead@^1.0.0:
   integrity sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=
   dependencies:
     flush-write-stream "^1.0.2"
+
+make-iterator@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/make-iterator/-/make-iterator-1.0.1.tgz#29b33f312aa8f547c4a5e490f56afcec99133ad6"
+  integrity sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==
+  dependencies:
+    kind-of "^6.0.2"
 
 merge2@^1.2.3, merge2@^1.3.0:
   version "1.3.0"
@@ -573,6 +666,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+stream-exhaust@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stream-exhaust/-/stream-exhaust-1.0.2.tgz#acdac8da59ef2bc1e17a2c0ccf6c320d120e555d"
+  integrity sha512-b/qaq/GlBK5xaq1yrK9/zFcyRSTNxmcZwFLGSTG0mXgZl/4Z6GgiyYOXOvY7N3eEvFRAG1bkDRz5EPGSvPYQlw==
 
 stream-shift@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## [0.2.1] - 2020-01-04
### Changed
- Slight improvements to README.md 'Basic Usage' example
- Clarify distinction between task execution error and task output error
- Use `bach` to execute tasks

### Fixed
- Prevent error when `watchMode` option is not specified
- Prevent piping to `vfs.dest` when `destination` is `null`